### PR TITLE
remove async tag in ModelsTable.tsx

### DIFF
--- a/components/ModelsTable.tsx
+++ b/components/ModelsTable.tsx
@@ -20,7 +20,7 @@ type ModelsTableProps = {
   models: modelRowWithSamples[];
 };
 
-export default async function ModelsTable({ models }: ModelsTableProps) {
+export default function ModelsTable({ models }: ModelsTableProps) {
   const router = useRouter();
   const handleRedirect = (id: number) => {
     router.push(`/overview/models/${id}`);


### PR DESCRIPTION
using async tag on client component causes error when user uses browser back navigation.